### PR TITLE
Audit fixes: assignments route, mocks toggle, route_view telemetry

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -1,5 +1,5 @@
-import React, { Suspense } from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import React, { Suspense, useEffect } from 'react';
+import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 
 import { init } from './init';
@@ -7,6 +7,7 @@ import { Layout } from '@/components/Layout';
 import { CommandPalette } from '@/components/CommandPalette';
 import { LoadingSpinner } from '@/components/LoadingSpinner';
 import { NAV } from '@/config/nav.config';
+import { trackRouteView } from '@/lib/telemetry';
 
 // Lazy load route components
 const PlannerPage = React.lazy(() => import('@/routes/PlannerPage'));
@@ -21,6 +22,13 @@ const DataPage = React.lazy(() => import('@/routes/DataPage'));
 init();
 
 function App(): JSX.Element {
+  const location = useLocation();
+
+  // Track route_view on navigation
+  useEffect(() => {
+    trackRouteView(location.pathname);
+  }, [location.pathname]);
+
   return (
     <div className="min-h-screen bg-secondary-50">
       <Layout>
@@ -48,6 +56,9 @@ function App(): JSX.Element {
                   />
                 );
               })}
+
+              {/* Backwards-compatible alias for /assignment */}
+              <Route path="/assignment" element={<AssignmentPage />} />
               
               {/* Admin routes */}
               <Route

--- a/apps/web/src/config/nav.config.ts
+++ b/apps/web/src/config/nav.config.ts
@@ -77,7 +77,7 @@ export const NAV = {
         {
           id: 'assignment',
           label: 'Assignments',
-          path: '/assignment',
+          path: '/assignments',
           icon: UserCheck,
           description: 'Task and resource assignments',
           requiresAuth: true,


### PR DESCRIPTION
Align nav/router to /assignments, honor VITE_USE_MOCKS=1 in api.ts, add route_view telemetry and wire to router.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - “Assignments” now lives at /assignments; the legacy /assignment URL still works.
  - Basic route view tracking added to improve analytics coverage.

- Improvements
  - More consistent date/time display across the app due to normalized timestamp handling.
  - Backend interactions streamlined with environment-aware behavior to improve reliability and responsiveness in different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->