### PR TITLE
ci(a11y): add Lighthouse budgets and Axe scan

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -118,10 +118,33 @@ jobs:
       - name: Install Lighthouse CI
         run: npm install -g @lhci/cli@0.12.x
 
-      - name: Run Lighthouse CI
+      - name: Run Lighthouse CI (with budgets)
         run: lhci autorun
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+
+      - name: Start preview server
+        run: npm run preview &
+
+      - name: Wait for preview to be ready
+        run: |
+          for i in {1..30}; do
+            if curl -sSf http://localhost:5000 > /dev/null; then
+              echo "Preview is up"; break;
+            fi
+            echo "Waiting for preview... ($i)"; sleep 1;
+          done
+
+      - name: Run Axe scan (Puppeteer)
+        run: npm run axe
+
+      - name: Upload Axe report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: axe-report
+          path: axe-report.json
+          retention-days: 14
 
   # Security audit
   security-audit:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -263,15 +263,19 @@ jobs:
           # Add smoke tests here to verify production deployment
           curl -f ${{ secrets.PRODUCTION_URL }}/health || exit 1
 
-      - name: Notify deployment
-        uses: 8398a7/action-slack@v3
-        if: always()
-        with:
-          status: ${{ job.status }}
-          channel: '#deployments'
-          webhook_url: ${{ secrets.SLACK_WEBHOOK }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+      - name: Notify Slack (success)
+        if: ${{ success() && secrets.SLACK_WEBHOOK != '' }}
+        run: |
+          MSG="✅ CI passed on $GITHUB_REPOSITORY@$GITHUB_REF ($GITHUB_SHA)"
+          payload=$(printf '{"text":"%s"}' "$MSG")
+          curl -X POST -H 'Content-type: application/json' --data "$payload" "${{ secrets.SLACK_WEBHOOK }}"
+
+      - name: Notify Slack (failure)
+        if: ${{ failure() && secrets.SLACK_WEBHOOK != '' }}
+        run: |
+          MSG="❌ CI failed on $GITHUB_REPOSITORY@$GITHUB_REF ($GITHUB_SHA)"
+          payload=$(printf '{"text":"%s"}' "$MSG")
+          curl -X POST -H 'Content-type: application/json' --data "$payload" "${{ secrets.SLACK_WEBHOOK }}"
 
   # Performance monitoring
   performance-monitoring:

--- a/budgets.json
+++ b/budgets.json
@@ -1,0 +1,15 @@
+{
+  "resourceSizes": [
+    { "resourceType": "script", "budget": 275 },
+    { "resourceType": "document", "budget": 50 },
+    { "resourceType": "stylesheet", "budget": 120 },
+    { "resourceType": "font", "budget": 200 },
+    { "resourceType": "image", "budget": 600 },
+    { "resourceType": "media", "budget": 0 },
+    { "resourceType": "other", "budget": 100 }
+  ],
+  "resourceCounts": [
+    { "resourceType": "total", "budget": 120 },
+    { "resourceType": "script", "budget": 40 }
+  ]
+}

--- a/lighthouse.config.js
+++ b/lighthouse.config.js
@@ -5,6 +5,9 @@ module.exports = {
       startServerCommand: 'npm run preview',
       startServerReadyPattern: 'Local:',
       startServerReadyTimeout: 30000,
+      settings: {
+        budgetsPath: 'budgets.json',
+      },
     },
     assert: {
       assertions: {

--- a/ops/prompts/PROMPTS_LOG.md
+++ b/ops/prompts/PROMPTS_LOG.md
@@ -4,3 +4,4 @@
 |---|---|---|---|---|---|
 | 2025-10-05 | Homer | v1.0 | PR #1 | ops/prompts/archive/2025-10-05_homer_v1.0_prompt.txt | ops/prompts/archive/2025-10-05_homer_v1.0_summary.md |
 | 2025-10-05 | Homer | v1.1 | (this run) | ops/prompts/archive/2025-10-05_homer_v1.1_prompt.txt | ops/prompts/archive/2025-10-05_homer_v1.1_summary.md |
+| 2025-10-05 | Homer | v1.2 | branch ci/polish-budgets-axe (PR TBA) | ops/prompts/archive/2025-10-05_homer_v1.2_prompt.txt | ops/prompts/archive/2025-10-05_homer_v1.2_summary.md |

--- a/ops/prompts/PROMPTS_LOG.md
+++ b/ops/prompts/PROMPTS_LOG.md
@@ -5,3 +5,4 @@
 | 2025-10-05 | Homer | v1.0 | PR #1 | ops/prompts/archive/2025-10-05_homer_v1.0_prompt.txt | ops/prompts/archive/2025-10-05_homer_v1.0_summary.md |
 | 2025-10-05 | Homer | v1.1 | (this run) | ops/prompts/archive/2025-10-05_homer_v1.1_prompt.txt | ops/prompts/archive/2025-10-05_homer_v1.1_summary.md |
 | 2025-10-05 | Homer | v1.2 | PR #2 | ops/prompts/archive/2025-10-05_homer_v1.2_prompt.txt | ops/prompts/archive/2025-10-05_homer_v1.2_summary.md |
+| 2025-10-06 | Homer | v1.2F | branch ci/polish-budgets-axe (PR #2) | ops/prompts/archive/2025-10-05_homer_v1.2F_prompt.txt | ops/prompts/archive/2025-10-05_homer_v1.2F_summary.md |

--- a/ops/prompts/PROMPTS_LOG.md
+++ b/ops/prompts/PROMPTS_LOG.md
@@ -4,4 +4,4 @@
 |---|---|---|---|---|---|
 | 2025-10-05 | Homer | v1.0 | PR #1 | ops/prompts/archive/2025-10-05_homer_v1.0_prompt.txt | ops/prompts/archive/2025-10-05_homer_v1.0_summary.md |
 | 2025-10-05 | Homer | v1.1 | (this run) | ops/prompts/archive/2025-10-05_homer_v1.1_prompt.txt | ops/prompts/archive/2025-10-05_homer_v1.1_summary.md |
-| 2025-10-05 | Homer | v1.2 | branch ci/polish-budgets-axe (PR TBA) | ops/prompts/archive/2025-10-05_homer_v1.2_prompt.txt | ops/prompts/archive/2025-10-05_homer_v1.2_summary.md |
+| 2025-10-05 | Homer | v1.2 | PR #2 | ops/prompts/archive/2025-10-05_homer_v1.2_prompt.txt | ops/prompts/archive/2025-10-05_homer_v1.2_summary.md |

--- a/ops/prompts/archive/2025-10-05_homer_v1.2F_prompt.txt
+++ b/ops/prompts/archive/2025-10-05_homer_v1.2F_prompt.txt
@@ -1,0 +1,71 @@
+[HOMER v1.2F] Fix CI Slack step (remove unsupported webhook_url input), update ledger, push to PR #2.
+
+RULES
+- I am not a developer. Do ALL steps for me.
+- Patch the existing branch for PR #2: ci/polish-budgets-axe
+- Record THIS prompt text and a summary in ops/prompts.
+- Keep changes minimal; do not alter unrelated jobs.
+
+0) Prep
+set -euo pipefail
+pkill -f vite || true
+git fetch --all --prune
+git checkout main
+git pull --rebase origin main
+# Checkout PR #2 branch
+git checkout ci/polish-budgets-axe || git checkout -t origin/ci/polish-budgets-axe
+
+1) Replace Slack notify steps that use invalid 'webhook_url' input
+# Strategy: use a portable curl approach gated by secret presence.
+# - Success message: on job success
+# - Failure message: on job failure
+# - Skip entirely if SLACK_WEBHOOK secret is not set
+# Apply this in .github/workflows/cicd.yml wherever Slack notify is used.
+
+# Edit cicd.yml:
+# - Remove any 'with: webhook_url: ${{ secrets.SLACK_WEBHOOK }}' blocks.
+# - Replace Slack steps with:
+#   - name: Notify Slack (success)
+#     if: ${{ success() && secrets.SLACK_WEBHOOK != '' }}
+#     run: |
+#       MSG="✅ CI passed on $GITHUB_REPOSITORY@$GITHUB_REF ($GITHUB_SHA)"
+#       payload=$(printf '{"text":"%s"}' "$MSG")
+#       curl -X POST -H 'Content-type: application/json' --data "$payload" "${{ secrets.SLACK_WEBHOOK }}"
+#   - name: Notify Slack (failure)
+#     if: ${{ failure() && secrets.SLACK_WEBHOOK != '' }}
+#     run: |
+#       MSG="❌ CI failed on $GITHUB_REPOSITORY@$GITHUB_REF ($GITHUB_SHA)"
+#       payload=$(printf '{"text":"%s"}' "$MSG")
+#       curl -X POST -H 'Content-type: application/json' --data "$payload" "${{ secrets.SLACK_WEBHOOK }}"
+
+# Notes:
+# - Keep existing jobs/names; just swap Slack steps.
+# - Do NOT fail the workflow if SLACK_WEBHOOK is missing; the 'if' guard prevents running.
+
+2) Optional: quiet editor “Context might be invalid” warnings
+# These are just editor hints. Do nothing functional.
+# Ensure we only reference secrets via ${{ secrets.NAME }} which is already correct.
+
+3) Prompts Ledger
+mkdir -p ops/prompts/archive
+cat > ops/prompts/archive/2025-10-05_homer_v1.2F_prompt.txt <<'PROMPT_END'
+[PASTE THE FULL HOMER v1.2F PROMPT TEXT HERE]
+PROMPT_END
+
+TS=$(date -u +%Y%m%d-%H%M%S)
+SUMMARY="ops/prompts/archive/2025-10-05_homer_v1.2F_summary.md"
+{
+  echo "# HOMER v1.2F Summary ($TS UTC)"
+  echo
+  echo "- Patched branch: ci/polish-budgets-axe (PR #2)"
+  echo "- Change: replace Slack notify steps with curl-based webhook; gated on secrets.SLACK_WEBHOOK"
+  echo "- Files changed: .github/workflows/cicd.yml; ops/prompts/archive/*v1.2F*"
+} > "$SUMMARY"
+
+if [ ! -f ops/prompts/PROMPTS_LOG.md ]; then
+  echo "# Prompts Ledger" > ops/prompts/PROMPTS_LOG.md
+  echo "" >> ops/prompts/PROMPTS_LOG.md
+  echo "| Date (UTC) | Agent | Version | Branch | PR | Prompt | Summary |" >> ops/prompts/PROMPTS_LOG.md
+  echo "|---|---|---|---|---|---|---|" >> ops/prompts/PROMPTS_LOG.md
+fi
+echo "| $TS | Homer | v1.2F | ci/polish-budgets-axe | https://github.com/${GITHUB_REPOSITORY}/pull/2 | ops/prompts/archive/2025-10-05_homer_v1.2F_prompt.txt | $SUMMARY |" >> ops/prompts/PROMPTS_LOG.md

--- a/ops/prompts/archive/2025-10-05_homer_v1.2F_summary.md
+++ b/ops/prompts/archive/2025-10-05_homer_v1.2F_summary.md
@@ -1,0 +1,5 @@
+# HOMER v1.2F Summary (auto)
+
+- Patched branch: ci/polish-budgets-axe (PR #2)
+- Change: replace Slack notify steps with curl-based webhook; gated on secrets.SLACK_WEBHOOK
+- Files changed: .github/workflows/cicd.yml; ops/prompts/archive/*v1.2F*

--- a/ops/prompts/archive/2025-10-05_homer_v1.2_prompt.txt
+++ b/ops/prompts/archive/2025-10-05_homer_v1.2_prompt.txt
@@ -1,0 +1,1 @@
+[HOMER v1.2] Add Lighthouse budgets + axe to CI, record this prompt + summary, open PR. Ensure LHCI uses budgets.json, add Axe scan against preview, and update Prompts Ledger. Commit, push branch ci/polish-budgets-axe, and open PR.

--- a/ops/prompts/archive/2025-10-05_homer_v1.2_summary.md
+++ b/ops/prompts/archive/2025-10-05_homer_v1.2_summary.md
@@ -1,0 +1,8 @@
+# HOMER v1.2 Summary
+
+- Created branch `ci/polish-budgets-axe`.
+- Added Lighthouse budgets in `budgets.json` and wired via `lighthouse.config.js` collect.settings.budgetsPath.
+- Enhanced CI a11y job to run LHCI with budgets and a separate Axe accessibility scan against a local preview server.
+- Implemented robust Axe scan via Puppeteer script `scripts/axe-scan.mjs`; added devDependencies and npm script.
+- Recorded this prompt and summary in the Prompts Ledger archive.
+- Next: commit, push branch, and open PR; iterate on any violations found by Axe/Lighthouse.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "concurrently \"npm run dev:web\" \"npm run dev:emulators\"",
     "dev:web": "npm run dev --workspace=apps/web",
     "dev:emulators": "firebase emulators:start",
+    "preview": "npm run preview --workspace=apps/web -- --port 5000",
     "build": "npm run build --workspace=apps/web && npm run build --workspace=functions",
     "test": "npm run test --workspaces",
     "test:unit": "npm run test --workspace=apps/web",
@@ -27,9 +28,12 @@
     "emulators:firestore": "firebase emulators:start --only firestore --project vizzy-local",
     "seed:raw": "tsx apps/web/scripts/seed.ts",
     "seed": "cross-env FIRESTORE_EMULATOR_HOST=127.0.0.1:8081 npm run seed:raw",
-    "seed:withEmu": "firebase emulators:exec --only firestore --project vizzy-local \"npm run seed:raw\""
+    "seed:withEmu": "firebase emulators:exec --only firestore --project vizzy-local \"npm run seed:raw\"",
+    "axe": "node ./scripts/axe-scan.mjs"
   },
   "devDependencies": {
+    "@axe-core/cli": "^4.9.1",
+    "@axe-core/puppeteer": "^4.9.1",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "concurrently": "^8.2.2",
@@ -37,6 +41,7 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
+  "puppeteer": "^22.13.1",
     "prettier": "^3.2.5",
     "tsx": "^4.20.6",
     "typescript": "^5.3.3"

--- a/scripts/axe-scan.mjs
+++ b/scripts/axe-scan.mjs
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+import puppeteer from 'puppeteer';
+import { AxePuppeteer } from '@axe-core/puppeteer';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+async function run() {
+  const target = process.env.AXE_TARGET_URL || 'http://localhost:5000';
+  const outPath = process.env.AXE_OUT || path.join(__dirname, '../axe-report.json');
+
+  const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] });
+  const page = await browser.newPage();
+  page.setDefaultNavigationTimeout(60000);
+  try {
+    await page.goto(target, { waitUntil: 'networkidle0' });
+
+    const results = await new AxePuppeteer(page)
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze();
+
+    fs.writeFileSync(outPath, JSON.stringify(results, null, 2));
+
+    const violations = results.violations || [];
+    console.log(`Axe scan complete. Violations: ${violations.length}`);
+    if (violations.length > 0) {
+      for (const v of violations) {
+        console.log(`- [${v.impact || 'n/a'}] ${v.id}: ${v.help} (${v.nodes.length} nodes)`);
+      }
+      // Exit non-zero so the job fails when issues are found
+      process.exitCode = 1;
+    }
+  } catch (err) {
+    console.error('Axe scan failed:', err);
+    process.exitCode = 2;
+  } finally {
+    await browser.close();
+  }
+}
+
+run();


### PR DESCRIPTION
This PR adds web performance budgets to Lighthouse CI and introduces an automated accessibility scan with Axe.\n\nChanges:\n- Added budgets.json and wired budgetsPath in lighthouse.config.js.\n- CI a11y job now runs LHCI with budgets and a Puppeteer-based Axe scan against a local preview server.\n- Added scripts/axe-scan.mjs with @axe-core/puppeteer + puppeteer, and npm script `npm run axe`.\n- Recorded HOMER v1.2 prompt and summary in ops/prompts and updated ledger.\n\nNotes:\n- Axe step fails the job on violations; review axe-report.json artifact.\n- Lighthouse category thresholds remain at >= 0.9; budgets gate payload growth.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Expanded accessibility CI to run Lighthouse with budgets, start a preview server with readiness checks, perform an Axe accessibility scan, and upload an axe-report artifact (14-day retention).
- Chores
  - Added performance/resource budgets, preview/axe scripts, and dev tooling to support automated accessibility checks.
  - Replaced single Slack deployment step with separate success and failure webhook notifications.
- Documentation
  - Updated prompts ledger and archived prompt/summary entries for this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->