### PR TITLE
feature: Dev Firebase behind toggle (keep mocks default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,12 @@ Generates AI-powered suggestions.
 ```
 
 ## 🆘 Troubleshooting
+## Dev Firebase Toggle
+
+- Default: MOCKS (no Firebase). See `apps/web/.env.example`.
+- To use real Firebase in dev: set `VITE_USE_MOCKS=0` in `apps/web/.env.local` and fill the `VITE_FIREBASE_*` vars.
+- Optional: set `VITE_USE_EMULATORS=1` to connect to local Auth/Firestore emulators.
+
 
 ### Common Issues
 

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -8,6 +8,7 @@ import { CommandPalette } from '@/components/CommandPalette';
 import { LoadingSpinner } from '@/components/LoadingSpinner';
 import { NAV } from '@/config/nav.config';
 import { trackRouteView } from '@/lib/telemetry';
+import { AuthGate } from './AuthGate';
 
 // Lazy load route components
 const PlannerPage = React.lazy(() => import('@/routes/PlannerPage'));
@@ -17,6 +18,7 @@ const CalendarPage = React.lazy(() => import('@/routes/CalendarPage'));
 const AssignmentPage = React.lazy(() => import('@/routes/AssignmentPage'));
 const AdminWrikeSchemaPage = React.lazy(() => import('@/routes/admin/WrikeSchemaPage'));
 const DataPage = React.lazy(() => import('@/routes/DataPage'));
+const LoginPage = React.lazy(() => import('@/routes/LoginPage'));
 
 // Initialize Firebase and app services
 init();
@@ -34,6 +36,7 @@ function App(): JSX.Element {
       <Layout>
         <Suspense fallback={<LoadingSpinner />}>
           <AnimatePresence mode="wait">
+            <AuthGate>
             <Routes>
               <Route path="/" element={<Navigate to="/planner" replace />} />
               
@@ -93,7 +96,9 @@ function App(): JSX.Element {
                   </div>
                 }
               />
+              <Route path="/login" element={<Suspense fallback={null}><LoginPage /></Suspense>} />
             </Routes>
+            </AuthGate>
           </AnimatePresence>
         </Suspense>
       </Layout>

--- a/apps/web/src/app/AuthGate.tsx
+++ b/apps/web/src/app/AuthGate.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import { isUsingMocks, createFirebase } from '@/lib/firebase';
+import { onAuthStateChanged, signInWithPopup, signOut, type User } from 'firebase/auth';
+
+export function AuthGate({ children }: { children: React.ReactNode }) {
+  if (isUsingMocks()) return <>{children}</>;
+
+  const fb = createFirebase();
+  if (!fb) return <>{children}</>;
+  const { auth } = fb;
+
+  const [user, setUser] = useState<User | null>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    return onAuthStateChanged(auth, (u) => {
+      setUser(u);
+      setReady(true);
+    });
+  }, [auth]);
+
+  if (!ready) return <div className="p-6 text-sm opacity-70">Loading…</div>;
+  if (!user)
+    return (
+      <div className="p-6">
+        <h1 className="text-xl font-semibold mb-2">Sign in</h1>
+        <button
+          className="px-4 py-2 rounded bg-black text-white"
+          onClick={async () => {
+            const { GoogleAuthProvider } = createFirebase()!;
+            await signInWithPopup(auth, new GoogleAuthProvider());
+          }}
+        >
+          Continue with Google
+        </button>
+      </div>
+    );
+
+  return <>{children}</>;
+}
+
+export function SignOutButton() {
+  if (isUsingMocks()) return null;
+  const fb = createFirebase();
+  if (!fb) return null;
+  const { auth } = fb;
+  return (
+    <button className="px-3 py-1 rounded border" onClick={() => signOut(auth)}>
+      Sign out
+    </button>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -13,18 +13,15 @@ import {
   writeBatch
 } from 'firebase/firestore';
 import { httpsCallable } from 'firebase/functions';
-import { db, functions } from '@/app/init';
+import { isUsingMocks, createFirebase } from '@/lib/firebase';
 import { trackApiCall, trackError } from '@/lib/telemetry';
 import { mockApi } from '@/lib/mockData';
 
 // Check if we're in development mode and should use mock data
-const envAny = (import.meta as any).env || {};
-const isDev = envAny.VITE_ENV === 'dev' || Boolean(envAny.DEV);
-const mockFlag = String(envAny.VITE_USE_MOCKS || '').toLowerCase();
-const useMockData = (
-  mockFlag === '1' || mockFlag === 'true' ||
-  (isDev && envAny.VITE_FIREBASE_PROJECT_ID === 'vizzy-local')
-);
+const useMockData = isUsingMocks();
+const fb = createFirebase();
+const db = fb?.db as any;
+const functions = fb?.functions as any;
 
 export interface ApiResponse<T = unknown> {
   data: T;

--- a/apps/web/src/lib/firebase.ts
+++ b/apps/web/src/lib/firebase.ts
@@ -1,0 +1,42 @@
+import { initializeApp, getApps, type FirebaseApp } from 'firebase/app';
+import { getAuth, connectAuthEmulator, GoogleAuthProvider } from 'firebase/auth';
+import { getFirestore, connectFirestoreEmulator } from 'firebase/firestore';
+import { getFunctions } from 'firebase/functions';
+
+const env = (import.meta as any).env || {};
+const useMocks = String(env.VITE_USE_MOCKS || '1').toLowerCase();
+const isMock = useMocks === '1' || useMocks === 'true';
+
+export const isUsingMocks = () => isMock;
+
+export function createFirebase() {
+  if (isMock) return null;
+
+  const cfg = {
+    apiKey: env.VITE_FIREBASE_API_KEY,
+    authDomain: env.VITE_FIREBASE_AUTH_DOMAIN,
+    projectId: env.VITE_FIREBASE_PROJECT_ID,
+    storageBucket: env.VITE_FIREBASE_STORAGE_BUCKET,
+    messagingSenderId: env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+    appId: env.VITE_FIREBASE_APP_ID,
+    measurementId: env.VITE_FIREBASE_MEASUREMENT_ID,
+  } as const;
+
+  const existing = getApps()[0] as FirebaseApp | undefined;
+  const app: FirebaseApp = existing ?? initializeApp(cfg);
+  const auth = getAuth(app);
+  const db = getFirestore(app);
+  const functions = getFunctions(app);
+
+  const useEmu = String(env.VITE_USE_EMULATORS || '0') === '1';
+  if (useEmu) {
+    const ah = env.VITE_AUTH_EMULATOR_HOST || '127.0.0.1';
+    const ap = Number(env.VITE_AUTH_EMULATOR_PORT || 9099);
+    const fh = env.VITE_FIRESTORE_EMULATOR_HOST || '127.0.0.1';
+    const fp = Number(env.VITE_FIRESTORE_EMULATOR_PORT || 8080);
+    try { connectAuthEmulator(auth, `http://${ah}:${ap}`); } catch {}
+    try { connectFirestoreEmulator(db, fh, fp); } catch {}
+  }
+
+  return { app, auth, db, functions, GoogleAuthProvider } as const;
+}

--- a/apps/web/src/routes/LoginPage.tsx
+++ b/apps/web/src/routes/LoginPage.tsx
@@ -1,0 +1,12 @@
+import { AuthGate } from '@/app/AuthGate';
+
+export default function LoginPage() {
+  return (
+    <AuthGate>
+      <div className="p-6">
+        <h1 className="text-2xl font-bold mb-2">You are signed in ✅</h1>
+        <p>Use the navigation to explore the app.</p>
+      </div>
+    </AuthGate>
+  );
+}

--- a/ops/prompts/PROMPTS_LOG.md
+++ b/ops/prompts/PROMPTS_LOG.md
@@ -7,3 +7,4 @@
 | 2025-10-05 | Homer | v1.2 | PR #2 | ops/prompts/archive/2025-10-05_homer_v1.2_prompt.txt | ops/prompts/archive/2025-10-05_homer_v1.2_summary.md |
 | 2025-10-06 | Homer | v1.2F | branch ci/polish-budgets-axe (PR #2) | ops/prompts/archive/2025-10-05_homer_v1.2F_prompt.txt | ops/prompts/archive/2025-10-05_homer_v1.2F_summary.md |
 | 2025-10-06 | Homer | v1.2M | main (PR #2) | ops/prompts/archive/2025-10-05_homer_v1.2M_prompt.txt | ops/prompts/archive/2025-10-05_homer_v1.2M_summary.md |
+| 2025-10-06 | Homer | v1.3 | feature/dev-firebase-toggle-20251006-002255 (new PR) | ops/prompts/archive/2025-10-05_homer_v1.3_prompt.txt | ops/prompts/archive/2025-10-05_homer_v1.3_summary.md |

--- a/ops/prompts/archive/2025-10-05_homer_v1.3_prompt.txt
+++ b/ops/prompts/archive/2025-10-05_homer_v1.3_prompt.txt
@@ -1,0 +1,46 @@
+[HOMER v1.3] Wire Dev Firebase (auth + Firestore) behind an env toggle. Keep DEMO/MOCK as default. Record prompt+summary, create a branch, commit, push, and open a PR.
+
+RULES
+- Single feature branch only. No churn.
+- Do ALL steps. No questions.
+- No secrets in git. Use .env.local and .env.example only.
+
+0) Prep
+set -euo pipefail
+pkill -f vite || true
+git fetch --all --prune
+git checkout main
+git pull --rebase origin main
+TS=$(date -u +%Y%m%d-%H%M%S)
+BR="feature/dev-firebase-toggle-$TS"
+git checkout -b "$BR"
+
+1) Env templates (no secrets)
+# apps/web/.env.example
+... see task body ...
+
+2) Firebase bootstrap module
+# apps/web/src/lib/firebase.ts
+... see task body ...
+
+3) Minimal AuthGate and Login route (non-invasive)
+# apps/web/src/app/AuthGate.tsx
+# apps/web/src/routes/LoginPage.tsx
+... see task body ...
+
+4) Wire AuthGate around the app and add /login route
+# apps/web/src/app/App.tsx
+... see task body ...
+
+5) API: respect toggle (use Firestore when mocks OFF)
+# apps/web/src/lib/api.ts
+... see task body ...
+
+6) README note for dev Firebase
+... see task body ...
+
+7) Prompts Ledger (record prompt + summary)
+... see task body ...
+
+8) Commit, push, PR
+... see task body ...

--- a/ops/prompts/archive/2025-10-05_homer_v1.3_summary.md
+++ b/ops/prompts/archive/2025-10-05_homer_v1.3_summary.md
@@ -1,0 +1,5 @@
+# HOMER v1.3 Summary (auto)
+
+- Branch: feature/dev-firebase-toggle-<timestamp>
+- Added: .env.example, firebase.ts, AuthGate, LoginPage, App wrap, api.ts toggle, README note
+- Mocks remain default; Firebase only initializes when VITE_USE_MOCKS=0


### PR DESCRIPTION
Adds firebase.ts, AuthGate, /login, and API toggle. Default remains mocks (VITE_USE_MOCKS=1). To use Firebase in dev, set VITE_USE_MOCKS=0 and fill VITE_FIREBASE_*.

- apps/web/.env.example created (no secrets)
- AuthGate wraps <Routes> when mocks off
- Login page at /login
- api.ts sources db/functions via createFirebase()
- README: Dev Firebase Toggle section